### PR TITLE
Fix bug when using default get limit.

### DIFF
--- a/src/main/java/de/umass/lastfm/Library.java
+++ b/src/main/java/de/umass/lastfm/Library.java
@@ -70,7 +70,7 @@ public class Library {
 	 *
 	 * @param user The user whose library you want to fetch.
 	 * @param page The page number you wish to scan to.
-	 * @param limit Limit the amount of artists returned (maximum/default is 50).
+	 * @param limit Limit the number of artists returned (maximum/default is 50).
 	 * @param apiKey A Last.fm API key.
 	 * @return a {@link PaginatedResult} of the artists
 	 */
@@ -78,7 +78,8 @@ public class Library {
 		Map<String, String> params = new HashMap<String, String>();
 		params.put("user", user);
 		params.put("page", String.valueOf(page));
-		params.put("limit", String.valueOf(limit));
+		if (limit > 0)
+			params.put("limit", String.valueOf(limit));
 		Result result = Caller.getInstance().call("library.getArtists", apiKey, params);
 		return ResponseBuilder.buildPaginatedResult(result, Artist.class);
 	}
@@ -137,7 +138,7 @@ public class Library {
 	 *
 	 * @param user The user whose library you want to fetch.
 	 * @param page The page number you wish to scan to.
-	 * @param limit Limit the amount of albumss returned (maximum/default is 50).
+	 * @param limit Limit the number of albums returned (maximum/default is 50).
 	 * @param apiKey A Last.fm API key.
 	 * @return a {@link PaginatedResult} of the albums
 	 */
@@ -145,7 +146,8 @@ public class Library {
 		Map<String, String> params = new HashMap<String, String>();
 		params.put("user", user);
 		params.put("page", String.valueOf(page));
-		params.put("limit", String.valueOf(limit));
+		if (limit > 0)
+			params.put("limit", String.valueOf(limit));
 		Result result = Caller.getInstance().call("library.getAlbums", apiKey, params);
 		return ResponseBuilder.buildPaginatedResult(result, Album.class);
 	}
@@ -204,7 +206,7 @@ public class Library {
 	 *
 	 * @param user The user whose library you want to fetch.
 	 * @param page The page number you wish to scan to.
-	 * @param limit Limit the amount of albumss returned (maximum/default is 50).
+	 * @param limit Limit the number of albums returned (maximum/default is 50).
 	 * @param apiKey A Last.fm API key.
 	 * @return a {@link PaginatedResult} of the tracks
 	 */
@@ -212,7 +214,8 @@ public class Library {
 		Map<String, String> params = new HashMap<String, String>();
 		params.put("user", user);
 		params.put("page", String.valueOf(page));
-		params.put("limit", String.valueOf(limit));
+		if (limit > 0)
+			params.put("limit", String.valueOf(limit));
 		Result result = Caller.getInstance().call("library.getTracks", apiKey, params);
 		return ResponseBuilder.buildPaginatedResult(result, Track.class);
 	}


### PR DESCRIPTION
Bug:
The existing code passed 0 as the default page size limit when calling
getArtists, getAlbums or getTracks. However, this resulted in a response
from last.fm that contained the right data, but had empty strings as the
the page, perPage and totalPages attributes. These attributes then
failed to parse in ResponseBuilder, resulting in a
NumberFormatException.

To Reproduce:
Call Library.getArtists(String user, String apiKey) on a library with
less than 50 artists.

Fix:
To fix this I changed the library get methods (Library.getArtists,
Library.getAlbums and Library.getTracks) to omit the limit parameter
if limit <= 0. This results in last.fm using its default limit, which is
currently 50, and the response has the appropriate page, perPage and
totalPage attributes set, eliminating the parsing issue in
ResponseBuilder.
