### PR TITLE
Lastfm https

### DIFF
--- a/src/main/java/de/umass/lastfm/Authenticator.java
+++ b/src/main/java/de/umass/lastfm/Authenticator.java
@@ -39,7 +39,7 @@ import static de.umass.util.StringUtilities.md5;
 
 /**
  * Provides bindings for the authentication methods of the last.fm API.
- * See <a href="http://www.last.fm/api/authentication">http://www.last.fm/api/authentication</a> for
+ * See <a href="https://www.last.fm/api/authentication">https://www.last.fm/api/authentication</a> for
  * authentication methods.
  *
  * @author Janni Kovacs

--- a/src/main/java/de/umass/lastfm/Caller.java
+++ b/src/main/java/de/umass/lastfm/Caller.java
@@ -62,7 +62,7 @@ public class Caller {
 	private static final String PARAM_API_KEY = "api_key";
 	private static final String PARAM_METHOD = "method";
 
-	private static final String DEFAULT_API_ROOT = "http://ws.audioscrobbler.com/2.0/";
+	private static final String DEFAULT_API_ROOT = "https://ws.audioscrobbler.com/2.0/";
 	private static final Caller instance = new Caller();
 	
 	private final Logger log = Logger.getLogger("de.umass.lastfm.Caller");

--- a/src/main/java/de/umass/lastfm/Event.java
+++ b/src/main/java/de/umass/lastfm/Event.java
@@ -115,7 +115,7 @@ public class Event extends ImageHolder {
 	}
 
 	/**
-	 * Returns the last.fm event url, i.e. http://www.last.fm/event/event-id
+	 * Returns the last.fm event url, i.e. https://www.last.fm/event/event-id
 	 *
 	 * @return last.fm url
 	 */

--- a/src/main/java/de/umass/lastfm/Playlist.java
+++ b/src/main/java/de/umass/lastfm/Playlist.java
@@ -40,7 +40,7 @@ import java.util.List;
  * <li><b>User Playlists:</b> lastfm://playlist/{@literal <playlist_id>}</li>
  * <li><b>Tag Playlists:</b> lastfm://playlist/tag/{@literal <tag_name>}/freetracks</li>
  * </ul>
- * See <a href="http://www.last.fm/api/playlists">http://www.last.fm/api/playlists</a> for more information about playlists.
+ * See <a href="https://www.last.fm/api/playlists">https://www.last.fm/api/playlists</a> for more information about playlists.
  *
  * @author Janni Kovacs
  */

--- a/src/main/java/de/umass/lastfm/Radio.java
+++ b/src/main/java/de/umass/lastfm/Radio.java
@@ -36,7 +36,7 @@ import de.umass.xml.DomElement;
 /**
  * Provides access to the Last.fm radio streaming service.<br/>
  * Note that you have to be a subscriber (or have a special API key) to use this API.
- * Official documentation can be found here: <a href="http://www.last.fm/api/radio">http://www.last.fm/api/radio</a>
+ * Official documentation can be found here: <a href="https://www.last.fm/api/radio">https://www.last.fm/api/radio</a>
  *
  * @author Janni Kovacs
  */
@@ -240,7 +240,7 @@ public class Radio {
 		}
 
 		/**
-		 * @deprecated This station has been deprected as of nov. 2010, see <a href="http://www.last.fm/stationchanges2010">here</a>
+		 * @deprecated This station has been deprected as of nov. 2010, see <a href="https://www.last.fm/stationchanges2010">here</a>
 		 */
 		public static RadioStation lovedTracks(String user) {
 			return new RadioStation("lastfm://user/" + user + "/loved");
@@ -255,14 +255,14 @@ public class Radio {
 		}
 
 		/**
-		 * @deprecated This station has been deprected as of nov. 2010, see <a href="http://www.last.fm/stationchanges2010">here</a>
+		 * @deprecated This station has been deprected as of nov. 2010, see <a href="https://www.last.fm/stationchanges2010">here</a>
 		 */
 		public static RadioStation playlist(String playlistId) {
 			return new RadioStation("lastfm://playlist/" + playlistId);
 		}
 
 		/**
-		 * @deprecated This station has been deprected as of nov. 2010, see <a href="http://www.last.fm/stationchanges2010">here</a>
+		 * @deprecated This station has been deprected as of nov. 2010, see <a href="https://www.last.fm/stationchanges2010">here</a>
 		 */
 		public static RadioStation personalTag(String user, String tag) {
 			return new RadioStation("lastfm://usertags/" + user + "/" + tag);

--- a/src/main/java/de/umass/lastfm/Venue.java
+++ b/src/main/java/de/umass/lastfm/Venue.java
@@ -59,7 +59,7 @@ public class Venue extends ImageHolder {
 	}
 
 	/**
-	 * Returns a last.fm URL to this venue, e.g.: http://www.last.fm/venue/&lt;id&gt;-&lt;venue name&gt;
+	 * Returns a last.fm URL to this venue, e.g.: https://www.last.fm/venue/&lt;id&gt;-&lt;venue name&gt;
 	 *
 	 * @return last.fm url
 	 * @see #getWebsite()

--- a/src/main/java/de/umass/lastfm/scrobble/Rating.java
+++ b/src/main/java/de/umass/lastfm/scrobble/Rating.java
@@ -27,7 +27,7 @@
 package de.umass.lastfm.scrobble;
 
 /**
- * The rating of the track. See <a href="http://www.last.fm/api/submissions#subs">http://www.last.fm/api/submissions#subs</a>
+ * The rating of the track. See <a href="https://www.last.fm/api/submissions#subs">https://www.last.fm/api/submissions#subs</a>
  * for more information.
  *
  * @author Lukasz Wisniewski

--- a/src/main/java/de/umass/lastfm/scrobble/Scrobbler.java
+++ b/src/main/java/de/umass/lastfm/scrobble/Scrobbler.java
@@ -49,7 +49,7 @@ import static de.umass.util.StringUtilities.md5;
  * {@link #newScrobbler(String, String, String) newScrobbler}.<br/>
  * It contains methods to perform the handshake, notify Last.fm about a now playing song and submitting songs to a musical profile, aka
  * scrobbling songs.<br/>
- * See <a href="http://www.last.fm/api/submissions">http://www.last.fm/api/submissions</a> for a deeper explanation of the protocol and
+ * See <a href="https://www.last.fm/api/submissions">https://www.last.fm/api/submissions</a> for a deeper explanation of the protocol and
  * various guidelines on how to use the scrobbling service, since this class does not cover error handling or caching.<br/>
  * All methods in this class, which are communicating with the server, return an instance of {@link ResponseStatus} which contains
  * information if the operation was successful or not.<br/>

--- a/src/main/java/de/umass/lastfm/scrobble/Source.java
+++ b/src/main/java/de/umass/lastfm/scrobble/Source.java
@@ -27,7 +27,7 @@
 package de.umass.lastfm.scrobble;
 
 /**
- * The source of the track. See <a href="http://www.last.fm/api/submissions#subs">http://www.last.fm/api/submissions#subs</a> for more
+ * The source of the track. See <a href="https://www.last.fm/api/submissions#subs">https://www.last.fm/api/submissions#subs</a> for more
  * information.
  *
  * @author Janni Kovacs


### PR DESCRIPTION
Update web services root URL to https
* auth.getMobileSession will soon no longer work over HTTP, and all calls are now supported over HTTPS.

Update all docblock links to https



